### PR TITLE
fix bug that swapped width and height in _get_logical_screen_descriptor

### DIFF
--- a/array2gif/core.py
+++ b/array2gif/core.py
@@ -121,8 +121,8 @@ def get_color_table_size(num_colors):
 
 
 def _get_logical_screen_descriptor(image, colors):
-    width = len(image)
-    height = len(image[0])
+    height = len(image)
+    width = len(image[0])
     global_color_table_flag = '1'
     # color resolution possibly doesn't do anything, because
     # the size of the colors in the global color table is always


### PR DESCRIPTION
I discovered this bug trying to generate rectangular images (512 pixels wide by 256 pixels tall).  The result was that the image's width and height were swapped and the bottom half (or right half depending on aspect ratio) would come out all black.  The fix is simple, I'm guessing this wasn't encountered before because you're usually working with square images?